### PR TITLE
Get pinboard/panel icon name from .desktop files.

### DIFF
--- a/ROX-Filer/src/icon.c
+++ b/ROX-Filer/src/icon.c
@@ -444,6 +444,9 @@ GType icon_get_type(void)
  */
 void icon_set_path(Icon *icon, const char *pathname, const char *name)
 {
+	gchar 	*leafname = NULL;
+	GError *error = NULL;
+
 	if (icon->path)
 	{
 		icon_unhash_path(icon);
@@ -464,11 +467,30 @@ void icon_set_path(Icon *icon, const char *pathname, const char *name)
 
 		icon_hash_path(icon);
 
-		if (!name)
-			name = g_basename(icon->src_path);
+		if (!name) {
+			leafname = g_path_get_basename(icon->src_path);
+			name = leafname;
+		}
 
 		icon->item = diritem_new(name);
 		diritem_restat(icon->path, icon->item, NULL);
+
+		if (icon->item->mime_type == application_x_desktop)
+		{
+			leafname = get_value_from_desktop_file(
+					pathname, "Desktop Entry", "Name", &error);
+			if (leafname) {
+				if (error) {
+					g_free(leafname);
+				} else {
+					if (icon->item->leafname)
+						g_free(icon->item->leafname);
+					icon->item->leafname = leafname;
+				}
+			}
+		} else {
+			g_free(leafname);
+		}
 	}
 }
 

--- a/ROX-Filer/src/icon.c
+++ b/ROX-Filer/src/icon.c
@@ -475,7 +475,8 @@ void icon_set_path(Icon *icon, const char *pathname, const char *name)
 		icon->item = diritem_new(name);
 		diritem_restat(icon->path, icon->item, NULL);
 
-		g_free(leafname);
+		if (leafname)
+			g_free(leafname);
 
 		if (icon->item->mime_type == application_x_desktop)
 		{

--- a/ROX-Filer/src/icon.c
+++ b/ROX-Filer/src/icon.c
@@ -484,14 +484,14 @@ void icon_set_path(Icon *icon, const char *pathname, const char *name)
 			if (leafname) {
 				if (error) {
 					g_free(leafname);
-					g_free_error(error);
+					g_error_free(error);
 				} else {
 					if (icon->item->leafname)
 						g_free(icon->item->leafname);
 					icon->item->leafname = leafname;
 				}
 			} else if (error) {
-				g_free_error(error);
+				g_error_free(error);
 			}
 		}
 	}

--- a/ROX-Filer/src/icon.c
+++ b/ROX-Filer/src/icon.c
@@ -475,6 +475,8 @@ void icon_set_path(Icon *icon, const char *pathname, const char *name)
 		icon->item = diritem_new(name);
 		diritem_restat(icon->path, icon->item, NULL);
 
+		g_free(leafname);
+
 		if (icon->item->mime_type == application_x_desktop)
 		{
 			leafname = get_value_from_desktop_file(
@@ -482,14 +484,15 @@ void icon_set_path(Icon *icon, const char *pathname, const char *name)
 			if (leafname) {
 				if (error) {
 					g_free(leafname);
+					g_free_error(error);
 				} else {
 					if (icon->item->leafname)
 						g_free(icon->item->leafname);
 					icon->item->leafname = leafname;
 				}
+			} else if (error) {
+				g_free_error(error);
 			}
-		} else {
-			g_free(leafname);
 		}
 	}
 }


### PR DESCRIPTION
When dropping a .desktop file to the panel/pinboard, set the icon's name to the .desktop file's "Name" entry.
