### PR TITLE
Add an option that restricts detailed icon views to one column.

### DIFF
--- a/ROX-Filer/Options.xml
+++ b/ROX-Filer/Options.xml
@@ -8,6 +8,7 @@
         <radio label='Always resize' value='1'>The filer will resize windows whenever it seems useful (that is, when changing directory or display style).</radio>
       </radio-group>
       <numentry name='filer_size_limit' label='Largest window size:' unit='%' min='1' max='100' width='3'>The largest size, as a percentage of the screen size, that the auto-resizer will resize a window to.</numentry>
+      <toggle name='filer_details_one_column' label='Use only one column when showing details'>If this is on, then icon views with details will only occupy a single column.</toggle>
     </frame>
     <frame label='Window behaviour'>
       <hbox>

--- a/ROX-Filer/src/filer.c
+++ b/ROX-Filer/src/filer.c
@@ -173,7 +173,7 @@ static gboolean not_local = FALSE;
 static Option o_short_flag_names;
 static Option o_filer_view_type;
 Option o_filer_auto_resize, o_unique_filer_windows;
-Option o_filer_size_limit;
+Option o_filer_size_limit, o_filer_details_one_column;
 
 #define ROX_RESPONSE_EJECT 99 /**< User clicked on Eject button */
 
@@ -184,6 +184,7 @@ void filer_init(void)
 	gchar *dpyhost, *tmp;
   
 	option_add_int(&o_filer_size_limit, "filer_size_limit", 75);
+	option_add_int(&o_filer_details_one_column, "filer_details_one_column", 0);
 	option_add_int(&o_filer_auto_resize, "filer_auto_resize",
 							RESIZE_ALWAYS);
 	option_add_int(&o_unique_filer_windows, "filer_unique_windows", 0);

--- a/ROX-Filer/src/filer.h
+++ b/ROX-Filer/src/filer.h
@@ -122,7 +122,7 @@ extern FilerWindow 	*window_with_focus;
 extern GList		*all_filer_windows;
 extern GHashTable	*child_to_filer;
 extern Option		o_filer_auto_resize, o_unique_filer_windows;
-extern Option		o_filer_size_limit;
+extern Option		o_filer_size_limit, o_filer_details_one_column;
 
 /* Prototypes */
 void filer_init(void);

--- a/ROX-Filer/src/view_collection.c
+++ b/ROX-Filer/src/view_collection.c
@@ -1514,7 +1514,11 @@ static void view_collection_autosize(ViewIface *view)
 		x = max_x;
 
 	cols = x / w;
-	cols = MAX(cols, 1);
+	if (o_filer_details_one_column.int_value &&
+	    filer_window->details_type != DETAILS_NONE)
+		cols = 1;
+	else
+		cols = MAX(cols, 1);
 
 	/* Choose rows to display all items given our chosen x.
 	 * Don't make the window *too* big!


### PR DESCRIPTION
Increasingly useful on big displays.

I've been carrying this patch since 2007; I have a vague memory that I submitted it before and you rejected it... but if you can think of a better way of getting the same effect then please let me know!
