### PR TITLE
Allow sorting by atime and ctime as well as mtime.

### DIFF
--- a/ROX-Filer/Options.xml
+++ b/ROX-Filer/Options.xml
@@ -39,6 +39,8 @@
               <item label='Name' value='0'/>
               <item label='Type' value='1'/>
               <item label='Date' value='2'/>
+              <item label='Last Accessed' value='6'/>
+              <item label='Last Changed' value='7'/>
               <item label='Size' value='3'/>
             </menu>
           </vbox><vbox>

--- a/ROX-Filer/Options.xml
+++ b/ROX-Filer/Options.xml
@@ -38,7 +38,7 @@
             <menu name='display_sort_by' label='Sort by:' sizegroup='disp-def'>
               <item label='Name' value='0'/>
               <item label='Type' value='1'/>
-              <item label='Date' value='2'/>
+              <item label='Last Modified' value='2'/>
               <item label='Last Accessed' value='6'/>
               <item label='Last Changed' value='7'/>
               <item label='Size' value='3'/>

--- a/ROX-Filer/src/Docs/Manual.xml
+++ b/ROX-Filer/src/Docs/Manual.xml
@@ -3268,7 +3268,7 @@ EOF</screen>
      <parameter>Style</parameter> is one of <userinput>Large</userinput>, <userinput>Small</userinput>, <userinput>Huge</userinput>
      or <userinput>Automatic</userinput>.
      <parameter>Details</parameter> is one of <userinput>None</userinput>, <userinput>ListView</userinput>, <userinput>Size</userinput>, <userinput>Type</userinput>, <userinput>Times</userinput> or <userinput>Permissions</userinput>.
-     <parameter>Sort</parameter> is one of <userinput>Name</userinput>, <userinput>Type</userinput>, <userinput>Date</userinput>, <userinput>Size</userinput>,
+     <parameter>Sort</parameter> is one of <userinput>Name</userinput>, <userinput>Type</userinput>, <userinput>Date</userinput>, <userinput>LastAccessed</userinput>, <userinput>LastChanged</userinput>, <userinput>Size</userinput>,
 <userinput>Owner</userinput> or <userinput>Group</userinput>.
      If any of these three option parameters are missing, the default is used.
      <parameter>Class</parameter> can be used to set the WM_CLASS property on the new window. You can

--- a/ROX-Filer/src/Docs/Manual.xml
+++ b/ROX-Filer/src/Docs/Manual.xml
@@ -3268,7 +3268,7 @@ EOF</screen>
      <parameter>Style</parameter> is one of <userinput>Large</userinput>, <userinput>Small</userinput>, <userinput>Huge</userinput>
      or <userinput>Automatic</userinput>.
      <parameter>Details</parameter> is one of <userinput>None</userinput>, <userinput>ListView</userinput>, <userinput>Size</userinput>, <userinput>Type</userinput>, <userinput>Times</userinput> or <userinput>Permissions</userinput>.
-     <parameter>Sort</parameter> is one of <userinput>Name</userinput>, <userinput>Type</userinput>, <userinput>Date</userinput>, <userinput>LastAccessed</userinput>, <userinput>LastChanged</userinput>, <userinput>Size</userinput>,
+     <parameter>Sort</parameter> is one of <userinput>Name</userinput>, <userinput>Type</userinput>, <userinput>LastModified</userinput>, <userinput>LastAccessed</userinput>, <userinput>LastChanged</userinput>, <userinput>Size</userinput>,
 <userinput>Owner</userinput> or <userinput>Group</userinput>.
      If any of these three option parameters are missing, the default is used.
      <parameter>Class</parameter> can be used to set the WM_CLASS property on the new window. You can

--- a/ROX-Filer/src/display.c
+++ b/ROX-Filer/src/display.c
@@ -411,7 +411,7 @@ int sort_by_group(const void *item1, const void *item2)
 	return strcmp(name1, name2);
 }
 
-int sort_by_date(const void *item1, const void *item2)
+int sort_by_mtime(const void *item1, const void *item2)
 {
 	const DirItem *i1 = (DirItem *) item1;
 	const DirItem *i2 = (DirItem *) item2;

--- a/ROX-Filer/src/display.c
+++ b/ROX-Filer/src/display.c
@@ -694,16 +694,16 @@ static char *details(FilerWindow *filer_window, DirItem *item)
 	}
 	else if (filer_window->details_type == DETAILS_TIMES)
 	{
-		guchar	*ctime, *mtime, *atime;
+		guchar	*mtime, *atime, *ctime;
 		
-		ctime = pretty_time(&item->ctime);
 		mtime = pretty_time(&item->mtime);
 		atime = pretty_time(&item->atime);
+		ctime = pretty_time(&item->ctime);
 		
-		buf = g_strdup_printf("a[%s] c[%s] m[%s]", atime, ctime, mtime);
-		g_free(ctime);
+		buf = g_strdup_printf("m[%s] a[%s] c[%s]", mtime, atime, ctime);
 		g_free(mtime);
 		g_free(atime);
+		g_free(ctime);
 	}
 	else if (filer_window->details_type == DETAILS_PERMISSIONS)
 	{

--- a/ROX-Filer/src/display.c
+++ b/ROX-Filer/src/display.c
@@ -423,6 +423,30 @@ int sort_by_date(const void *item1, const void *item2)
 		sort_by_name(item1, item2);
 }
 
+int sort_by_atime(const void *item1, const void *item2)
+{
+	const DirItem *i1 = (DirItem *) item1;
+	const DirItem *i2 = (DirItem *) item2;
+
+	/* SORT_DIRS; -- too confusing! */
+
+	return i1->atime < i2->atime ? -1 :
+		i1->atime > i2->atime ? 1 :
+		sort_by_name(item1, item2);
+}
+
+int sort_by_ctime(const void *item1, const void *item2)
+{
+	const DirItem *i1 = (DirItem *) item1;
+	const DirItem *i2 = (DirItem *) item2;
+
+	/* SORT_DIRS; -- too confusing! */
+
+	return i1->ctime < i2->ctime ? -1 :
+		i1->ctime > i2->ctime ? 1 :
+		sort_by_name(item1, item2);
+}
+
 int sort_by_size(const void *item1, const void *item2)
 {
 	const DirItem *i1 = (DirItem *) item1;

--- a/ROX-Filer/src/display.h
+++ b/ROX-Filer/src/display.h
@@ -48,7 +48,7 @@ void display_set_filter(FilerWindow *filer_window, FilterType type,
 void display_set_thumbs(FilerWindow *filer_window, gboolean thumbs);
 int sort_by_name(const void *item1, const void *item2);
 int sort_by_type(const void *item1, const void *item2);
-int sort_by_date(const void *item1, const void *item2);
+int sort_by_mtime(const void *item1, const void *item2);
 int sort_by_atime(const void *item1, const void *item2);
 int sort_by_ctime(const void *item1, const void *item2);
 int sort_by_size(const void *item1, const void *item2);

--- a/ROX-Filer/src/display.h
+++ b/ROX-Filer/src/display.h
@@ -49,6 +49,8 @@ void display_set_thumbs(FilerWindow *filer_window, gboolean thumbs);
 int sort_by_name(const void *item1, const void *item2);
 int sort_by_type(const void *item1, const void *item2);
 int sort_by_date(const void *item1, const void *item2);
+int sort_by_atime(const void *item1, const void *item2);
+int sort_by_ctime(const void *item1, const void *item2);
 int sort_by_size(const void *item1, const void *item2);
 int sort_by_owner(const void *item1, const void *item2);
 int sort_by_group(const void *item1, const void *item2);

--- a/ROX-Filer/src/global.h
+++ b/ROX-Filer/src/global.h
@@ -139,7 +139,7 @@ typedef enum {		/* Values used in options, must start at 0 */
 typedef enum {		/* Values used in options */
 	SORT_NAME = 0,
 	SORT_TYPE = 1,
-	SORT_DATE = 2,
+	SORT_MTIME = 2,
 	SORT_ATIME = 6,
 	SORT_CTIME = 7,
 	SORT_SIZE = 3,

--- a/ROX-Filer/src/global.h
+++ b/ROX-Filer/src/global.h
@@ -140,6 +140,8 @@ typedef enum {		/* Values used in options */
 	SORT_NAME = 0,
 	SORT_TYPE = 1,
 	SORT_DATE = 2,
+	SORT_ATIME = 6,
+	SORT_CTIME = 7,
 	SORT_SIZE = 3,
 	SORT_OWNER = 4,
 	SORT_GROUP = 5

--- a/ROX-Filer/src/menu.c
+++ b/ROX-Filer/src/menu.c
@@ -197,7 +197,7 @@ static GtkItemFactoryEntry filer_menu_def[] = {
 {">",				NULL, NULL, 0, "<Separator>"},
 {">" N_("Sort by Name"),	NULL, set_sort, SORT_NAME, NULL},
 {">" N_("Sort by Type"),	NULL, set_sort, SORT_TYPE, NULL},
-{">" N_("Sort by Date"),	NULL, set_sort, SORT_DATE, NULL},
+{">" N_("Sort by Last Modified"),	NULL, set_sort, SORT_MTIME, NULL},
 {">" N_("Sort by Last Accessed"),	NULL, set_sort, SORT_ATIME, NULL},
 {">" N_("Sort by Last Changed"),	NULL, set_sort, SORT_CTIME, NULL},
 {">" N_("Sort by Size"),	NULL, set_sort, SORT_SIZE, NULL},

--- a/ROX-Filer/src/menu.c
+++ b/ROX-Filer/src/menu.c
@@ -198,6 +198,8 @@ static GtkItemFactoryEntry filer_menu_def[] = {
 {">" N_("Sort by Name"),	NULL, set_sort, SORT_NAME, NULL},
 {">" N_("Sort by Type"),	NULL, set_sort, SORT_TYPE, NULL},
 {">" N_("Sort by Date"),	NULL, set_sort, SORT_DATE, NULL},
+{">" N_("Sort by Last Accessed"),	NULL, set_sort, SORT_ATIME, NULL},
+{">" N_("Sort by Last Changed"),	NULL, set_sort, SORT_CTIME, NULL},
 {">" N_("Sort by Size"),	NULL, set_sort, SORT_SIZE, NULL},
 {">" N_("Sort by Owner"),	NULL, set_sort, SORT_OWNER, NULL},
 {">" N_("Sort by Group"),	NULL, set_sort, SORT_GROUP, NULL},

--- a/ROX-Filer/src/remote.c
+++ b/ROX-Filer/src/remote.c
@@ -763,7 +763,8 @@ static xmlNodePtr rpc_OpenDir(GList *args)
 
 		type = !g_ascii_strcasecmp(sort, "Name") ? SORT_NAME :
 		       !g_ascii_strcasecmp(sort, "Type") ? SORT_TYPE :
-		       !g_ascii_strcasecmp(sort, "Date") ? SORT_DATE :
+		       !g_ascii_strcasecmp(sort, "LastModified") ? SORT_MTIME :
+		       !g_ascii_strcasecmp(sort, "Date") ? SORT_MTIME : /* for backwards compatibility */
 		       !g_ascii_strcasecmp(sort, "LastAccessed") ? SORT_ATIME :
 		       !g_ascii_strcasecmp(sort, "LastChanged") ? SORT_CTIME :
 		       !g_ascii_strcasecmp(sort, "Size") ? SORT_SIZE :

--- a/ROX-Filer/src/remote.c
+++ b/ROX-Filer/src/remote.c
@@ -764,6 +764,8 @@ static xmlNodePtr rpc_OpenDir(GList *args)
 		type = !g_ascii_strcasecmp(sort, "Name") ? SORT_NAME :
 		       !g_ascii_strcasecmp(sort, "Type") ? SORT_TYPE :
 		       !g_ascii_strcasecmp(sort, "Date") ? SORT_DATE :
+		       !g_ascii_strcasecmp(sort, "LastAccessed") ? SORT_ATIME :
+		       !g_ascii_strcasecmp(sort, "LastChanged") ? SORT_CTIME :
 		       !g_ascii_strcasecmp(sort, "Size") ? SORT_SIZE :
 		       !g_ascii_strcasecmp(sort, "Owner") ? SORT_OWNER :
 		       !g_ascii_strcasecmp(sort, "Group") ? SORT_GROUP :

--- a/ROX-Filer/src/toolbar.c
+++ b/ROX-Filer/src/toolbar.c
@@ -438,12 +438,15 @@ static void toolbar_sort_clicked(GtkWidget *widget,
 	gchar *tip;
 
 	static const SortType sorts[]={
-		SORT_NAME, SORT_TYPE, SORT_DATE, SORT_SIZE,
-		SORT_OWNER, SORT_GROUP, 
+		SORT_NAME, SORT_TYPE,
+		SORT_DATE, SORT_ATIME, SORT_CTIME,
+		SORT_SIZE, SORT_OWNER, SORT_GROUP,
 	};
 	static const char *sort_names[] = {
-		N_("Sort by name"), N_("Sort by type"), N_("Sort by date"), 
-		N_("Sort by size"), N_("Sort by owner"), N_("Sort by group"), 
+		N_("Sort by name"), N_("Sort by type"),
+		N_("Sort by date"),
+		N_("Sort by last accessed"), N_("Sort by last changed"),
+		N_("Sort by size"), N_("Sort by owner"), N_("Sort by group"),
 	};
 
 	bev = (GdkEventButton *) get_current_event(GDK_BUTTON_RELEASE);

--- a/ROX-Filer/src/toolbar.c
+++ b/ROX-Filer/src/toolbar.c
@@ -439,12 +439,12 @@ static void toolbar_sort_clicked(GtkWidget *widget,
 
 	static const SortType sorts[]={
 		SORT_NAME, SORT_TYPE,
-		SORT_DATE, SORT_ATIME, SORT_CTIME,
+		SORT_MTIME, SORT_ATIME, SORT_CTIME,
 		SORT_SIZE, SORT_OWNER, SORT_GROUP,
 	};
 	static const char *sort_names[] = {
 		N_("Sort by name"), N_("Sort by type"),
-		N_("Sort by date"),
+		N_("Sort by last modified"),
 		N_("Sort by last accessed"), N_("Sort by last changed"),
 		N_("Sort by size"), N_("Sort by owner"), N_("Sort by group"),
 	};

--- a/ROX-Filer/src/view_collection.c
+++ b/ROX-Filer/src/view_collection.c
@@ -1033,6 +1033,8 @@ static SortFn sort_fn(FilerWindow *fw)
 		case SORT_NAME: return sort_by_name;
 		case SORT_TYPE: return sort_by_type;
 		case SORT_DATE: return sort_by_date;
+		case SORT_ATIME: return sort_by_atime;
+		case SORT_CTIME: return sort_by_ctime;
 		case SORT_SIZE: return sort_by_size;
 		case SORT_OWNER: return sort_by_owner;
 		case SORT_GROUP: return sort_by_group;

--- a/ROX-Filer/src/view_collection.c
+++ b/ROX-Filer/src/view_collection.c
@@ -1032,7 +1032,7 @@ static SortFn sort_fn(FilerWindow *fw)
 	{
 		case SORT_NAME: return sort_by_name;
 		case SORT_TYPE: return sort_by_type;
-		case SORT_DATE: return sort_by_date;
+		case SORT_MTIME: return sort_by_mtime;
 		case SORT_ATIME: return sort_by_atime;
 		case SORT_CTIME: return sort_by_ctime;
 		case SORT_SIZE: return sort_by_size;

--- a/ROX-Filer/src/view_details.c
+++ b/ROX-Filer/src/view_details.c
@@ -535,7 +535,7 @@ static gboolean details_get_sort_column_id(GtkTreeSortable *sortable,
 	{
 		case SORT_NAME: col = COL_LEAF; break;
 		case SORT_TYPE: col = COL_TYPE; break;
-		case SORT_DATE: col = COL_MTIME; break;
+		case SORT_MTIME: col = COL_MTIME; break;
 		case SORT_ATIME: col = COL_ATIME; break;
 		case SORT_CTIME: col = COL_CTIME; break;
 		case SORT_SIZE: col = COL_SIZE; break;
@@ -571,7 +571,7 @@ static void details_set_sort_column_id(GtkTreeSortable     *sortable,
 			display_set_sort_type(filer_window, SORT_SIZE, order);
 			break;
 		case COL_MTIME:
-			display_set_sort_type(filer_window, SORT_DATE, order);
+			display_set_sort_type(filer_window, SORT_MTIME, order);
 			break;
 		case COL_ATIME:
 			display_set_sort_type(filer_window, SORT_ATIME, order);
@@ -1202,7 +1202,7 @@ static void resort(ViewDetails *view_details)
 	{
 		case SORT_NAME: view_details->sort_fn = sort_by_name; break;
 		case SORT_TYPE: view_details->sort_fn = sort_by_type; break;
-		case SORT_DATE: view_details->sort_fn = sort_by_date; break;
+		case SORT_MTIME: view_details->sort_fn = sort_by_mtime; break;
 		case SORT_ATIME: view_details->sort_fn = sort_by_atime; break;
 		case SORT_CTIME: view_details->sort_fn = sort_by_ctime; break;
 		case SORT_SIZE: view_details->sort_fn = sort_by_size; break;

--- a/ROX-Filer/src/view_details.c
+++ b/ROX-Filer/src/view_details.c
@@ -50,11 +50,13 @@
 #define COL_GROUP 4
 #define COL_SIZE 5
 #define COL_MTIME 6
-#define COL_ITEM 7
-#define COL_COLOUR 8
-#define COL_WEIGHT 9
-#define COL_VIEW_ITEM 10
-#define N_COLUMNS 11
+#define COL_ATIME 7
+#define COL_CTIME 8
+#define COL_ITEM 9
+#define COL_COLOUR 10
+#define COL_WEIGHT 11
+#define COL_VIEW_ITEM 12
+#define N_COLUMNS 13
 
 static gpointer parent_class = NULL;
 
@@ -355,9 +357,16 @@ static void details_get_value(GtkTreeModel *tree_model,
 			g_value_set_string(value, group_name(item->gid));
 			break;
 		case COL_MTIME:
+		case COL_ATIME:
+		case COL_CTIME:
 		{
 			gchar *time;
-			time = pretty_time(&item->mtime);
+			if (column == COL_MTIME)
+				time = pretty_time(&item->mtime);
+			else if (column == COL_ATIME)
+				time = pretty_time(&item->atime);
+			else
+				time = pretty_time(&item->ctime);
 			g_value_init(value, G_TYPE_STRING);
 			g_value_set_string(value, time);
 			g_free(time);
@@ -527,6 +536,8 @@ static gboolean details_get_sort_column_id(GtkTreeSortable *sortable,
 		case SORT_NAME: col = COL_LEAF; break;
 		case SORT_TYPE: col = COL_TYPE; break;
 		case SORT_DATE: col = COL_MTIME; break;
+		case SORT_ATIME: col = COL_ATIME; break;
+		case SORT_CTIME: col = COL_CTIME; break;
 		case SORT_SIZE: col = COL_SIZE; break;
 		case SORT_OWNER: col = COL_OWNER; break;
 		case SORT_GROUP: col = COL_GROUP; break;
@@ -561,6 +572,12 @@ static void details_set_sort_column_id(GtkTreeSortable     *sortable,
 			break;
 		case COL_MTIME:
 			display_set_sort_type(filer_window, SORT_DATE, order);
+			break;
+		case COL_ATIME:
+			display_set_sort_type(filer_window, SORT_ATIME, order);
+			break;
+		case COL_CTIME:
+			display_set_sort_type(filer_window, SORT_CTIME, order);
 			break;
 		case COL_TYPE:
 			display_set_sort_type(filer_window, SORT_TYPE, order);
@@ -1077,6 +1094,10 @@ static void view_details_init(GTypeInstance *object, gpointer gclass)
 	gtk_tree_view_column_set_sort_column_id(column, COL_SIZE);
 	ADD_TEXT_COLUMN(_("Last _Modified"), COL_MTIME);
 	gtk_tree_view_column_set_sort_column_id(column, COL_MTIME);
+	ADD_TEXT_COLUMN(_("Last _Accessed"), COL_ATIME);
+	gtk_tree_view_column_set_sort_column_id(column, COL_ATIME);
+	ADD_TEXT_COLUMN(_("Last _Changed"), COL_CTIME);
+	gtk_tree_view_column_set_sort_column_id(column, COL_CTIME);
 }
 
 /* Create the handers for the View interface */
@@ -1182,6 +1203,8 @@ static void resort(ViewDetails *view_details)
 		case SORT_NAME: view_details->sort_fn = sort_by_name; break;
 		case SORT_TYPE: view_details->sort_fn = sort_by_type; break;
 		case SORT_DATE: view_details->sort_fn = sort_by_date; break;
+		case SORT_ATIME: view_details->sort_fn = sort_by_atime; break;
+		case SORT_CTIME: view_details->sort_fn = sort_by_ctime; break;
 		case SORT_SIZE: view_details->sort_fn = sort_by_size; break;
 		case SORT_OWNER: view_details->sort_fn = sort_by_owner; break;
 		case SORT_GROUP: view_details->sort_fn = sort_by_group; break;


### PR DESCRIPTION
I often want to sort by ctime. (I'm not sure how useful atime is... but "with Times" did show it already.)

The changes are straightforward enough, but I'm a bit antsy about the impact this has on the translations, hence the split commits to optionally keep "Sort by Date" intact.
