### PR TITLE
Fix compilation with GCC10

### DIFF
--- a/ROX-Filer/src/session.h
+++ b/ROX-Filer/src/session.h
@@ -10,7 +10,7 @@
 #include <gtk/gtk.h>
 #include <X11/SM/SMlib.h>
 
-gboolean session_auto_respawn;
+extern gboolean session_auto_respawn;
 
 void session_init(const gchar *client_id);
 


### PR DESCRIPTION
Fixed compilation when -fno-common enabled (in GCC10 by default). See https://bugs.gentoo.org/710330.